### PR TITLE
Restricted token faucet

### DIFF
--- a/src/RestrictedTokenFaucet.sol
+++ b/src/RestrictedTokenFaucet.sol
@@ -1,0 +1,51 @@
+pragma solidity >=0.5.0;
+
+interface ERC20Like {
+    function balanceOf(address) external view returns (uint256);
+    function transfer(address,uint256) external; // return bool?
+}
+
+contract TokenFaucet {
+    // --- Auth ---
+    mapping (address => uint) public wards;
+    function rely(address guy) public auth { wards[guy] = 1; }
+    function deny(address guy) public auth { wards[guy] = 0; }
+    modifier auth { require(wards[msg.sender] == 1); _; }
+
+    uint256 public amt;
+    mapping (address => mapping (address => bool)) public done;
+
+    constructor (uint256 amt_) public {
+        wards[msg.sender] = 1;
+        amt = amt_;
+    }
+
+    function mul(uint x, uint y) internal pure returns (uint z) {
+        require(y == 0 || (z = x * y) / y == x);
+    }
+
+    function gulp(address gem) external {
+        require(!done[msg.sender][address(gem)], "token-faucet: already used faucet");
+        require(ERC20Like(gem).balanceOf(address(this)) >= amt, "token-faucet: not enough balance");
+        done[msg.sender][address(gem)] = true;
+        ERC20Like(gem).transfer(msg.sender, amt);
+    }
+
+    function gulp(address gem, address payable [] calldata addrs) external {
+        require(ERC20Like(gem).balanceOf(address(this)) >= mul(amt, addrs.length), "token-faucet: not enough balance");
+
+        for (uint i = 0; i < addrs.length; i++) {
+            require(!done[addrs[i]][address(gem)], "token-faucet: already used faucet");
+            done[addrs[i]][address(gem)] = true;
+            ERC20Like(gem).transfer(addrs[i], amt);
+        }
+    }
+
+    function shut(ERC20Like gem) external auth {
+        gem.transfer(msg.sender, gem.balanceOf(address(this)));
+    }
+
+    function setamt(uint256 amt_) external auth {
+        amt = amt_;
+    }
+}

--- a/src/RestrictedTokenFaucet.sol
+++ b/src/RestrictedTokenFaucet.sol
@@ -34,7 +34,7 @@ contract RestrictedTokenFaucet {
         ERC20Like(gem).transfer(msg.sender, amt);
     }
 
-    function gulp(address gem, address payable[] calldata addrs) external {
+    function gulp(address gem, address[] calldata addrs) external {
         require(ERC20Like(gem).balanceOf(address(this)) >= mul(amt, addrs.length), "token-faucet: not enough balance");
 
         for (uint i = 0; i < addrs.length; i++) {

--- a/src/RestrictedTokenFaucet.sol
+++ b/src/RestrictedTokenFaucet.sol
@@ -5,7 +5,7 @@ interface ERC20Like {
     function transfer(address,uint256) external; // return bool?
 }
 
-contract TokenFaucet {
+contract RestrictedTokenFaucet {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address guy) public auth { wards[guy] = 1; }
@@ -31,7 +31,7 @@ contract TokenFaucet {
         ERC20Like(gem).transfer(msg.sender, amt);
     }
 
-    function gulp(address gem, address payable [] calldata addrs) external {
+    function gulp(address gem, address payable[] calldata addrs) external {
         require(ERC20Like(gem).balanceOf(address(this)) >= mul(amt, addrs.length), "token-faucet: not enough balance");
 
         for (uint i = 0; i < addrs.length; i++) {

--- a/src/RestrictedTokenFaucet.sol
+++ b/src/RestrictedTokenFaucet.sol
@@ -19,8 +19,6 @@ contract RestrictedTokenFaucet {
     function hope(address guy) public auth { list[guy] = 1; }
     function nope(address guy) public auth { list[guy] = 0; }
 
-    address public owner;
-
     uint256 public amt;
     mapping (address => mapping (address => bool)) public done;
 

--- a/src/RestrictedTokenFaucet.sol
+++ b/src/RestrictedTokenFaucet.sol
@@ -49,7 +49,7 @@ contract RestrictedTokenFaucet {
         gem.transfer(msg.sender, gem.balanceOf(address(this)));
     }
 
-    function unDone(address usr, address gem) external isOwner {
+    function undo(address usr, address gem) external isOwner {
         done[usr][gem] = false;
     }
 

--- a/src/RestrictedTokenFaucet.sol
+++ b/src/RestrictedTokenFaucet.sol
@@ -8,10 +8,17 @@ interface ERC20Like {
 contract RestrictedTokenFaucet {
     // --- Auth ---
     mapping (address => uint) public wards;
-    function rely(address guy) public isOwner { wards[guy] = 1; }
-    function deny(address guy) public isOwner { wards[guy] = 0; }
-    modifier auth { require(wards[msg.sender] == 1); _; }
-    modifier isOwner { require(owner == msg.sender); _; }
+    function rely(address guy) public auth { wards[guy] = 1; }
+    function deny(address guy) public auth { wards[guy] = 0; }
+    modifier auth {
+        require(wards[msg.sender] == 1, "token-faucet/no-auth");
+        _;
+    }
+    // --- Gulp Whitelist ---
+    mapping (address => uint) public list;
+    function hope(address guy) public auth { list[guy] = 1; }
+    function nope(address guy) public auth { list[guy] = 0; }
+
     address public owner;
 
     uint256 public amt;
@@ -19,41 +26,42 @@ contract RestrictedTokenFaucet {
 
     constructor (uint256 amt_) public {
         wards[msg.sender] = 1;
-        owner = msg.sender;
+        list[msg.sender] = 1;
         amt = amt_;
     }
 
     function mul(uint x, uint y) internal pure returns (uint z) {
-        require(y == 0 || (z = x * y) / y == x);
+        require(y == 0 || (z = x * y) / y == x, "token-faucet/mul-overflow");
     }
 
-    function gulp(address gem) external auth {
-        require(!done[msg.sender][address(gem)], "token-faucet: already used faucet");
-        require(ERC20Like(gem).balanceOf(address(this)) >= amt, "token-faucet: not enough balance");
-        done[msg.sender][address(gem)] = true;
+    function gulp(address gem) external  {
+        require(list[address(0)] == 1 || list[msg.sender] == 1, "token-faucet/no-whitelist");
+        require(!done[msg.sender][gem], "token-faucet/already-used_faucet");
+        require(ERC20Like(gem).balanceOf(address(this)) >= amt, "token-faucet/not-enough-balance");
+        done[msg.sender][gem] = true;
         ERC20Like(gem).transfer(msg.sender, amt);
     }
 
     function gulp(address gem, address[] calldata addrs) external {
-        require(ERC20Like(gem).balanceOf(address(this)) >= mul(amt, addrs.length), "token-faucet: not enough balance");
+        require(ERC20Like(gem).balanceOf(address(this)) >= mul(amt, addrs.length), "token-faucet/not-enough-balance");
 
         for (uint i = 0; i < addrs.length; i++) {
-            require(wards[addrs[i]] == 1, "token-faucet: address not authed");
-            require(!done[addrs[i]][address(gem)], "token-faucet: already used faucet");
+            require(list[address(0)] == 1 || list[addrs[i]] == 1, "token-faucet/no-whitelist");
+            require(!done[addrs[i]][address(gem)], "token-faucet/already-used-faucet");
             done[addrs[i]][address(gem)] = true;
             ERC20Like(gem).transfer(addrs[i], amt);
         }
     }
 
-    function shut(ERC20Like gem) external isOwner {
+    function shut(ERC20Like gem) external auth {
         gem.transfer(msg.sender, gem.balanceOf(address(this)));
     }
 
-    function undo(address usr, address gem) external isOwner {
+    function undo(address usr, address gem) external auth {
         done[usr][gem] = false;
     }
 
-    function setamt(uint256 amt_) external isOwner {
+    function setamt(uint256 amt_) external auth {
         amt = amt_;
     }
 }

--- a/src/RestrictedTokenFaucet.t.sol
+++ b/src/RestrictedTokenFaucet.t.sol
@@ -47,9 +47,9 @@ contract RestrictedTokenFaucetTest is DSTest {
     address self;
 
     function setUp() public {
-        faucet = new RestrictedTokenFaucet(20 ether);
+        faucet = new RestrictedTokenFaucet(20);
         token = new DSToken("TEST");
-        token.mint(address(faucet), 1000000 ether);
+        token.mint(address(faucet), 1000000);
         user1 = address(new FaucetUser(token, faucet));
         user2 = address(new FaucetUser(token, faucet));
         self = address(this);
@@ -71,7 +71,7 @@ contract RestrictedTokenFaucetTest is DSTest {
         assertEq(faucet.wards(user1), 1);
         assertEq(token.balanceOf(user1), 0);
         FaucetUser(user1).doGulp();
-        assertEq(token.balanceOf(user1), 20 ether);
+        assertEq(token.balanceOf(user1), 20);
     }
 
     function testFail_rely_not_owner() public {
@@ -97,10 +97,10 @@ contract RestrictedTokenFaucetTest is DSTest {
         assertEq(token.balanceOf(address(567)), 0);
         assertEq(token.balanceOf(address(890)), 0);
         faucet.gulp(address(token), addrs);
-        assertEq(token.balanceOf(address(123)), 20 ether);
-        assertEq(token.balanceOf(address(234)), 20 ether);
-        assertEq(token.balanceOf(address(567)), 20 ether);
-        assertEq(token.balanceOf(address(890)), 20 ether);
+        assertEq(token.balanceOf(address(123)), 20);
+        assertEq(token.balanceOf(address(234)), 20);
+        assertEq(token.balanceOf(address(567)), 20);
+        assertEq(token.balanceOf(address(890)), 20);
     }
 
     function testFail_gulp_multiple() public {
@@ -118,12 +118,12 @@ contract RestrictedTokenFaucetTest is DSTest {
     function test_undo() public {
         assertEq(token.balanceOf(address(this)), 0);
         faucet.gulp(address(token));
-        assertEq(token.balanceOf(address(this)), 20 ether);
+        assertEq(token.balanceOf(address(this)), 20);
         assertTrue(faucet.done(address(this), address(token)));
         faucet.undo(address(this), address(token));
         assertTrue(!faucet.done(address(this), address(token)));
         faucet.gulp(address(token));
-        assertEq(token.balanceOf(address(this)), 40 ether);
+        assertEq(token.balanceOf(address(this)), 40);
     }
 
     function testFail_undo_not_owner() public {
@@ -135,7 +135,7 @@ contract RestrictedTokenFaucetTest is DSTest {
     function test_shut() public {
         assertEq(token.balanceOf(address(this)), 0);
         faucet.shut(ERC20Like(address(token)));
-        assertEq(token.balanceOf(address(this)), 1000000 ether);
+        assertEq(token.balanceOf(address(this)), 1000000);
     }
 
     function testFail_shut_not_owner() public {
@@ -143,13 +143,13 @@ contract RestrictedTokenFaucetTest is DSTest {
     }
 
     function test_setamt() public {
-        assertEq(faucet.amt(), 20 ether);
-        faucet.setamt(10 ether);
-        assertEq(faucet.amt(), 10 ether);
+        assertEq(faucet.amt(), 20);
+        faucet.setamt(10);
+        assertEq(faucet.amt(), 10);
     }
 
     function testFail_setamt_not_owner() public {
-        FaucetUser(user1).doSetAmt(10 ether);
+        FaucetUser(user1).doSetAmt(10);
     }
 
     function() external payable {}

--- a/src/RestrictedTokenFaucet.t.sol
+++ b/src/RestrictedTokenFaucet.t.sol
@@ -117,11 +117,14 @@ contract RestrictedTokenFaucetTest is DSTest {
 
     function test_undo() public {
         assertEq(token.balanceOf(address(this)), 0);
+
         faucet.gulp(address(token));
         assertEq(token.balanceOf(address(this)), 20);
         assertTrue(faucet.done(address(this), address(token)));
+
         faucet.undo(address(this), address(token));
         assertTrue(!faucet.done(address(this), address(token)));
+
         faucet.gulp(address(token));
         assertEq(token.balanceOf(address(this)), 40);
     }

--- a/src/RestrictedTokenFaucet.t.sol
+++ b/src/RestrictedTokenFaucet.t.sol
@@ -74,11 +74,11 @@ contract RestrictedTokenFaucetTest is DSTest {
         assertEq(token.balanceOf(user1), 20 ether);
     }
 
-    function testFail_rely_notOwner() public {
+    function testFail_rely_not_owner() public {
         FaucetUser(user1).doRely(address(123));
     }
 
-    function testFail_deny_notOwner() public {
+    function testFail_deny_not_owner() public {
         FaucetUser(user1).doDeny(address(this));
     }
 
@@ -110,7 +110,7 @@ contract RestrictedTokenFaucetTest is DSTest {
         faucet.gulp(address(token), addrs);
     }
 
-    function testFail_gulpTwice() public {
+    function testFail_gulp_twice() public {
         faucet.gulp(address(token));
         faucet.gulp(address(token));
     }
@@ -126,7 +126,7 @@ contract RestrictedTokenFaucetTest is DSTest {
         assertEq(token.balanceOf(address(this)), 40 ether);
     }
 
-    function testFail_undo_notOwner() public {
+    function testFail_undo_not_owner() public {
         faucet.gulp(address(token));
         assertTrue(faucet.done(address(this), address(token)));
         FaucetUser(address(user1)).doUndo(address(this));
@@ -138,7 +138,7 @@ contract RestrictedTokenFaucetTest is DSTest {
         assertEq(token.balanceOf(address(this)), 1000000 ether);
     }
 
-    function testFail_shut_notOwner() public {
+    function testFail_shut_not_owner() public {
         FaucetUser(user1).doShut();
     }
 
@@ -148,7 +148,7 @@ contract RestrictedTokenFaucetTest is DSTest {
         assertEq(faucet.amt(), 10 ether);
     }
 
-    function testFail_setamt_notOwner() public {
+    function testFail_setamt_not_owner() public {
         FaucetUser(user1).doSetAmt(10 ether);
     }
 

--- a/src/RestrictedTokenFaucet.t.sol
+++ b/src/RestrictedTokenFaucet.t.sol
@@ -83,7 +83,7 @@ contract RestrictedTokenFaucetTest is DSTest {
     }
 
     function test_gulp_multiple() public {
-        address payable[] memory addrs = new address payable[](4);
+        address[] memory addrs = new address[](4);
         addrs[0] = address(123);
         faucet.rely(addrs[0]);
         addrs[1] = address(234);
@@ -104,7 +104,7 @@ contract RestrictedTokenFaucetTest is DSTest {
     }
 
     function testFail_gulp_multiple() public {
-        address payable[] memory addrs = new address payable[](4);
+        address[] memory addrs = new address[](4);
         addrs[0] = address(this); // already rely'ed
         addrs[1] = address(234); // not rely'ed
         faucet.gulp(address(token), addrs);

--- a/src/RestrictedTokenFaucet.t.sol
+++ b/src/RestrictedTokenFaucet.t.sol
@@ -154,6 +154,4 @@ contract RestrictedTokenFaucetTest is DSTest {
     function testFail_setamt_not_owner() public {
         user1.doSetAmt(10);
     }
-
-    function() external payable {}
 }

--- a/src/RestrictedTokenFaucet.t.sol
+++ b/src/RestrictedTokenFaucet.t.sol
@@ -3,14 +3,14 @@ pragma solidity ^0.5.4;
 import "ds-test/test.sol";
 import "ds-token/token.sol";
 
-import "./TokenFaucet.sol";
+import "./RestrictedTokenFaucet.sol";
 
-contract TokenFaucetTest is DSTest {
-    TokenFaucet faucet;
+contract RestrictedTokenFaucetTest is DSTest {
+    RestrictedTokenFaucet faucet;
     DSToken token;
 
     function setUp() public {
-        faucet = new TokenFaucet(20 ether);
+        faucet = new RestrictedTokenFaucet(20 ether);
         token = new DSToken("TEST");
         token.mint(address(faucet), 1000000 ether);
     }
@@ -26,7 +26,7 @@ contract TokenFaucetTest is DSTest {
         assertEq(token.balanceOf(address(234)), 0);
         assertEq(token.balanceOf(address(567)), 0);
         assertEq(token.balanceOf(address(890)), 0);
-        address payable [] memory addrs = new address payable [](4);
+        address payable[] memory addrs = new address payable[](4);
         addrs[0] = address(123);
         addrs[1] = address(234);
         addrs[2] = address(567);
@@ -40,7 +40,7 @@ contract TokenFaucetTest is DSTest {
 
     function testFail_gulp_multiple() public {
         faucet.gulp(address(token));
-        address payable [] memory addrs = new address payable [](4);
+        address payable[] memory addrs = new address payable[](4);
         addrs[0] = address(this);
         addrs[1] = address(234);
         addrs[2] = address(567);

--- a/src/RestrictedTokenFaucet.t.sol
+++ b/src/RestrictedTokenFaucet.t.sol
@@ -22,12 +22,12 @@ contract FaucetUser {
         faucet.undo(usr, address(token));
     }
 
-    function doRely(address usr) public {
-        faucet.rely(usr);
+    function doHope(address usr) public {
+        faucet.hope(usr);
     }
 
-    function doDeny(address usr) public {
-        faucet.deny(usr);
+    function doNope(address usr) public {
+        faucet.nope(usr);
     }
 
     function doShut() public {
@@ -57,41 +57,50 @@ contract RestrictedTokenFaucetTest is DSTest {
 
     function testSetupPrecondition() public {
         assertEq(faucet.wards(self), 1);
-        assertEq(faucet.owner(), self);
-        assertEq(faucet.wards(address(user1)), 0);
-        assertEq(faucet.wards(address(user2)), 0);
+        assertEq(faucet.list(self), 1);
+        assertEq(faucet.list(address(user1)), 0);
+        assertEq(faucet.list(address(user2)), 0);
     }
 
-    function testFail_gulp_no_auth() public {
+    function testFail_gulp_no_auth_list() public {
         FaucetUser(user2).doGulp();
     }
 
-    function test_gulp_auth() public {
-        faucet.rely(address(user1));
-        assertEq(faucet.wards(address(user1)), 1);
+    function test_gulp_auth_list() public {
+        faucet.hope(address(user1));
+        assertEq(faucet.list(address(user1)), 1);
         assertEq(token.balanceOf(address(user1)), 0);
         user1.doGulp();
         assertEq(token.balanceOf(address(user1)), 20);
     }
 
-    function testFail_rely_not_owner() public {
-        user1.doRely(address(123));
+    function test_gulp_auth_list_all() public {
+        faucet.hope(address(0));
+        assertEq(faucet.list(address(0)), 1);
+        assertEq(faucet.list(address(user1)), 0);
+        assertEq(token.balanceOf(address(user1)), 0);
+        user1.doGulp();
+        assertEq(token.balanceOf(address(user1)), 20);
     }
 
-    function testFail_deny_not_owner() public {
-        user1.doDeny(address(this));
+    function testFail_hope_not_owner() public {
+        user1.doHope(address(123));
+    }
+
+    function testFail_nope_not_owner() public {
+        user1.doNope(address(this));
     }
 
     function test_gulp_multiple() public {
         address[] memory addrs = new address[](4);
         addrs[0] = address(123);
-        faucet.rely(addrs[0]);
+        faucet.hope(addrs[0]);
         addrs[1] = address(234);
-        faucet.rely(addrs[1]);
+        faucet.hope(addrs[1]);
         addrs[2] = address(567);
-        faucet.rely(addrs[2]);
+        faucet.hope(addrs[2]);
         addrs[3] = address(890);
-        faucet.rely(addrs[3]);
+        faucet.hope(addrs[3]);
         assertEq(token.balanceOf(address(123)), 0);
         assertEq(token.balanceOf(address(234)), 0);
         assertEq(token.balanceOf(address(567)), 0);
@@ -104,9 +113,9 @@ contract RestrictedTokenFaucetTest is DSTest {
     }
 
     function testFail_gulp_multiple() public {
-        address[] memory addrs = new address[](4);
-        addrs[0] = address(this); // already rely'ed
-        addrs[1] = address(234); // not rely'ed
+        address[] memory addrs = new address[](2);
+        addrs[0] = address(this); // already hope'ed
+        addrs[2] = address(234); // not hope'ed
         faucet.gulp(address(token), addrs);
     }
 

--- a/src/RestrictedTokenFaucet.t.sol
+++ b/src/RestrictedTokenFaucet.t.sol
@@ -42,24 +42,24 @@ contract FaucetUser {
 contract RestrictedTokenFaucetTest is DSTest {
     RestrictedTokenFaucet faucet;
     DSToken token;
-    address user1;
-    address user2;
+    FaucetUser user1;
+    FaucetUser user2;
     address self;
 
     function setUp() public {
         faucet = new RestrictedTokenFaucet(20);
         token = new DSToken("TEST");
         token.mint(address(faucet), 1000000);
-        user1 = address(new FaucetUser(token, faucet));
-        user2 = address(new FaucetUser(token, faucet));
+        user1 = new FaucetUser(token, faucet);
+        user2 = new FaucetUser(token, faucet);
         self = address(this);
     }
 
     function testSetupPrecondition() public {
         assertEq(faucet.wards(self), 1);
         assertEq(faucet.owner(), self);
-        assertEq(faucet.wards(user1), 0);
-        assertEq(faucet.wards(user2), 0);
+        assertEq(faucet.wards(address(user1)), 0);
+        assertEq(faucet.wards(address(user2)), 0);
     }
 
     function testFail_gulp_no_auth() public {
@@ -67,19 +67,19 @@ contract RestrictedTokenFaucetTest is DSTest {
     }
 
     function test_gulp_auth() public {
-        faucet.rely(user1);
-        assertEq(faucet.wards(user1), 1);
-        assertEq(token.balanceOf(user1), 0);
-        FaucetUser(user1).doGulp();
-        assertEq(token.balanceOf(user1), 20);
+        faucet.rely(address(user1));
+        assertEq(faucet.wards(address(user1)), 1);
+        assertEq(token.balanceOf(address(user1)), 0);
+        user1.doGulp();
+        assertEq(token.balanceOf(address(user1)), 20);
     }
 
     function testFail_rely_not_owner() public {
-        FaucetUser(user1).doRely(address(123));
+        user1.doRely(address(123));
     }
 
     function testFail_deny_not_owner() public {
-        FaucetUser(user1).doDeny(address(this));
+        user1.doDeny(address(this));
     }
 
     function test_gulp_multiple() public {
@@ -132,7 +132,7 @@ contract RestrictedTokenFaucetTest is DSTest {
     function testFail_undo_not_owner() public {
         faucet.gulp(address(token));
         assertTrue(faucet.done(address(this), address(token)));
-        FaucetUser(address(user1)).doUndo(address(this));
+        user1.doUndo(address(this));
     }
 
     function test_shut() public {
@@ -142,7 +142,7 @@ contract RestrictedTokenFaucetTest is DSTest {
     }
 
     function testFail_shut_not_owner() public {
-        FaucetUser(user1).doShut();
+        user1.doShut();
     }
 
     function test_setamt() public {
@@ -152,7 +152,7 @@ contract RestrictedTokenFaucetTest is DSTest {
     }
 
     function testFail_setamt_not_owner() public {
-        FaucetUser(user1).doSetAmt(10);
+        user1.doSetAmt(10);
     }
 
     function() external payable {}

--- a/src/RestrictedTokenFaucet.t.sol
+++ b/src/RestrictedTokenFaucet.t.sol
@@ -18,10 +18,6 @@ contract FaucetUser {
         faucet.gulp(address(token));
     }
 
-    function doBalanceOf() public view returns(uint) {
-        return token.balanceOf(address(this));
-    }
-
     function doUndo(address usr) public {
         faucet.undo(usr, address(token));
     }
@@ -73,9 +69,9 @@ contract RestrictedTokenFaucetTest is DSTest {
     function test_gulp_auth() public {
         faucet.rely(user1);
         assertEq(faucet.wards(user1), 1);
-        assertEq(FaucetUser(user1).doBalanceOf(), 0);
+        assertEq(token.balanceOf(user1), 0);
         FaucetUser(user1).doGulp();
-        assertEq(FaucetUser(user1).doBalanceOf(), 20 ether);
+        assertEq(token.balanceOf(user1), 20 ether);
     }
 
     function testFail_rely_notOwner() public {

--- a/src/RestrictedTokenFaucet.t.sol
+++ b/src/RestrictedTokenFaucet.t.sol
@@ -22,8 +22,8 @@ contract FaucetUser {
         return token.balanceOf(address(this));
     }
 
-    function doUnDone(address usr) public {
-        faucet.unDone(usr, address(token));
+    function doUndo(address usr) public {
+        faucet.undo(usr, address(token));
     }
 
     function doRely(address usr) public {
@@ -119,21 +119,21 @@ contract RestrictedTokenFaucetTest is DSTest {
         faucet.gulp(address(token));
     }
 
-    function test_unDone() public {
+    function test_undo() public {
         assertEq(token.balanceOf(address(this)), 0);
         faucet.gulp(address(token));
         assertEq(token.balanceOf(address(this)), 20 ether);
         assertTrue(faucet.done(address(this), address(token)));
-        faucet.unDone(address(this), address(token));
+        faucet.undo(address(this), address(token));
         assertTrue(!faucet.done(address(this), address(token)));
         faucet.gulp(address(token));
         assertEq(token.balanceOf(address(this)), 40 ether);
     }
 
-    function testFail_unDone_notOwner() public {
+    function testFail_undo_notOwner() public {
         faucet.gulp(address(token));
         assertTrue(faucet.done(address(this), address(token)));
-        FaucetUser(address(user1)).doUnDone(address(this));
+        FaucetUser(address(user1)).doUndo(address(this));
     }
 
     function test_shut() public {

--- a/src/RestrictedTokenFaucet.t.sol
+++ b/src/RestrictedTokenFaucet.t.sol
@@ -5,32 +5,101 @@ import "ds-token/token.sol";
 
 import "./RestrictedTokenFaucet.sol";
 
+contract FaucetUser {
+    DSToken token;
+    RestrictedTokenFaucet faucet;
+
+    constructor(DSToken token_, RestrictedTokenFaucet faucet_) public {
+        token = token_;
+        faucet = faucet_;
+    }
+
+    function doGulp() public {
+        faucet.gulp(address(token));
+    }
+
+    function doBalanceOf() public view returns(uint) {
+        return token.balanceOf(address(this));
+    }
+
+    function doUnDone(address usr) public {
+        faucet.unDone(usr, address(token));
+    }
+
+    function doRely(address usr) public {
+        faucet.rely(usr);
+    }
+
+    function doDeny(address usr) public {
+        faucet.deny(usr);
+    }
+
+    function doShut() public {
+        faucet.shut(ERC20Like(address(this)));
+    }
+
+    function doSetAmt(uint amt) public {
+        faucet.setamt(amt);
+    }
+}
+
 contract RestrictedTokenFaucetTest is DSTest {
     RestrictedTokenFaucet faucet;
     DSToken token;
+    address user1;
+    address user2;
+    address self;
 
     function setUp() public {
         faucet = new RestrictedTokenFaucet(20 ether);
         token = new DSToken("TEST");
         token.mint(address(faucet), 1000000 ether);
+        user1 = address(new FaucetUser(token, faucet));
+        user2 = address(new FaucetUser(token, faucet));
+        self = address(this);
     }
 
-    function test_gulp() public {
-        assertEq(token.balanceOf(address(this)), 0);
-        faucet.gulp(address(token));
-        assertEq(token.balanceOf(address(this)), 20 ether);
+    function testSetupPrecondition() public {
+        assertEq(faucet.wards(self), 1);
+        assertEq(faucet.owner(), self);
+        assertEq(faucet.wards(user1), 0);
+        assertEq(faucet.wards(user2), 0);
+    }
+
+    function testFail_gulp_no_auth() public {
+        FaucetUser(user2).doGulp();
+    }
+
+    function test_gulp_auth() public {
+        faucet.rely(user1);
+        assertEq(faucet.wards(user1), 1);
+        assertEq(FaucetUser(user1).doBalanceOf(), 0);
+        FaucetUser(user1).doGulp();
+        assertEq(FaucetUser(user1).doBalanceOf(), 20 ether);
+    }
+
+    function testFail_rely_notOwner() public {
+        FaucetUser(user1).doRely(address(123));
+    }
+
+    function testFail_deny_notOwner() public {
+        FaucetUser(user1).doDeny(address(this));
     }
 
     function test_gulp_multiple() public {
+        address payable[] memory addrs = new address payable[](4);
+        addrs[0] = address(123);
+        faucet.rely(addrs[0]);
+        addrs[1] = address(234);
+        faucet.rely(addrs[1]);
+        addrs[2] = address(567);
+        faucet.rely(addrs[2]);
+        addrs[3] = address(890);
+        faucet.rely(addrs[3]);
         assertEq(token.balanceOf(address(123)), 0);
         assertEq(token.balanceOf(address(234)), 0);
         assertEq(token.balanceOf(address(567)), 0);
         assertEq(token.balanceOf(address(890)), 0);
-        address payable[] memory addrs = new address payable[](4);
-        addrs[0] = address(123);
-        addrs[1] = address(234);
-        addrs[2] = address(567);
-        addrs[3] = address(890);
         faucet.gulp(address(token), addrs);
         assertEq(token.balanceOf(address(123)), 20 ether);
         assertEq(token.balanceOf(address(234)), 20 ether);
@@ -39,18 +108,52 @@ contract RestrictedTokenFaucetTest is DSTest {
     }
 
     function testFail_gulp_multiple() public {
-        faucet.gulp(address(token));
         address payable[] memory addrs = new address payable[](4);
-        addrs[0] = address(this);
-        addrs[1] = address(234);
-        addrs[2] = address(567);
-        addrs[3] = address(890);
+        addrs[0] = address(this); // already rely'ed
+        addrs[1] = address(234); // not rely'ed
         faucet.gulp(address(token), addrs);
     }
 
     function testFail_gulpTwice() public {
         faucet.gulp(address(token));
         faucet.gulp(address(token));
+    }
+
+    function test_unDone() public {
+        assertEq(token.balanceOf(address(this)), 0);
+        faucet.gulp(address(token));
+        assertEq(token.balanceOf(address(this)), 20 ether);
+        assertTrue(faucet.done(address(this), address(token)));
+        faucet.unDone(address(this), address(token));
+        assertTrue(!faucet.done(address(this), address(token)));
+        faucet.gulp(address(token));
+        assertEq(token.balanceOf(address(this)), 40 ether);
+    }
+
+    function testFail_unDone_notOwner() public {
+        faucet.gulp(address(token));
+        assertTrue(faucet.done(address(this), address(token)));
+        FaucetUser(address(user1)).doUnDone(address(this));
+    }
+
+    function test_shut() public {
+        assertEq(token.balanceOf(address(this)), 0);
+        faucet.shut(ERC20Like(address(token)));
+        assertEq(token.balanceOf(address(this)), 1000000 ether);
+    }
+
+    function testFail_shut_notOwner() public {
+        FaucetUser(user1).doShut();
+    }
+
+    function test_setamt() public {
+        assertEq(faucet.amt(), 20 ether);
+        faucet.setamt(10 ether);
+        assertEq(faucet.amt(), 10 ether);
+    }
+
+    function testFail_setamt_notOwner() public {
+        FaucetUser(user1).doSetAmt(10 ether);
     }
 
     function() external payable {}

--- a/src/RestrictedTokenFaucet.t.sol
+++ b/src/RestrictedTokenFaucet.t.sol
@@ -1,0 +1,57 @@
+pragma solidity ^0.5.4;
+
+import "ds-test/test.sol";
+import "ds-token/token.sol";
+
+import "./TokenFaucet.sol";
+
+contract TokenFaucetTest is DSTest {
+    TokenFaucet faucet;
+    DSToken token;
+
+    function setUp() public {
+        faucet = new TokenFaucet(20 ether);
+        token = new DSToken("TEST");
+        token.mint(address(faucet), 1000000 ether);
+    }
+
+    function test_gulp() public {
+        assertEq(token.balanceOf(address(this)), 0);
+        faucet.gulp(address(token));
+        assertEq(token.balanceOf(address(this)), 20 ether);
+    }
+
+    function test_gulp_multiple() public {
+        assertEq(token.balanceOf(address(123)), 0);
+        assertEq(token.balanceOf(address(234)), 0);
+        assertEq(token.balanceOf(address(567)), 0);
+        assertEq(token.balanceOf(address(890)), 0);
+        address payable [] memory addrs = new address payable [](4);
+        addrs[0] = address(123);
+        addrs[1] = address(234);
+        addrs[2] = address(567);
+        addrs[3] = address(890);
+        faucet.gulp(address(token), addrs);
+        assertEq(token.balanceOf(address(123)), 20 ether);
+        assertEq(token.balanceOf(address(234)), 20 ether);
+        assertEq(token.balanceOf(address(567)), 20 ether);
+        assertEq(token.balanceOf(address(890)), 20 ether);
+    }
+
+    function testFail_gulp_multiple() public {
+        faucet.gulp(address(token));
+        address payable [] memory addrs = new address payable [](4);
+        addrs[0] = address(this);
+        addrs[1] = address(234);
+        addrs[2] = address(567);
+        addrs[3] = address(890);
+        faucet.gulp(address(token), addrs);
+    }
+
+    function testFail_gulpTwice() public {
+        faucet.gulp(address(token));
+        faucet.gulp(address(token));
+    }
+
+    function() external payable {}
+}

--- a/src/TokenFaucet.sol
+++ b/src/TokenFaucet.sol
@@ -31,7 +31,7 @@ contract TokenFaucet {
         ERC20Like(gem).transfer(msg.sender, amt);
     }
 
-    function gulp(address gem, address payable [] calldata addrs) external {
+    function gulp(address gem, address payable[] calldata addrs) external {
         require(ERC20Like(gem).balanceOf(address(this)) >= mul(amt, addrs.length), "token-faucet: not enough balance");
 
         for (uint i = 0; i < addrs.length; i++) {

--- a/src/TokenFaucet.sol
+++ b/src/TokenFaucet.sol
@@ -31,7 +31,7 @@ contract TokenFaucet {
         ERC20Like(gem).transfer(msg.sender, amt);
     }
 
-    function gulp(address gem, address payable[] calldata addrs) external {
+    function gulp(address gem, address[] calldata addrs) external {
         require(ERC20Like(gem).balanceOf(address(this)) >= mul(amt, addrs.length), "token-faucet: not enough balance");
 
         for (uint i = 0; i < addrs.length; i++) {

--- a/src/TokenFaucet.t.sol
+++ b/src/TokenFaucet.t.sol
@@ -10,15 +10,15 @@ contract TokenFaucetTest is DSTest {
     DSToken token;
 
     function setUp() public {
-        faucet = new TokenFaucet(20 ether);
+        faucet = new TokenFaucet(20);
         token = new DSToken("TEST");
-        token.mint(address(faucet), 1000000 ether);
+        token.mint(address(faucet), 1000000);
     }
 
     function test_gulp() public {
         assertEq(token.balanceOf(address(this)), 0);
         faucet.gulp(address(token));
-        assertEq(token.balanceOf(address(this)), 20 ether);
+        assertEq(token.balanceOf(address(this)), 20);
     }
 
     function test_gulp_multiple() public {
@@ -32,10 +32,10 @@ contract TokenFaucetTest is DSTest {
         addrs[2] = address(567);
         addrs[3] = address(890);
         faucet.gulp(address(token), addrs);
-        assertEq(token.balanceOf(address(123)), 20 ether);
-        assertEq(token.balanceOf(address(234)), 20 ether);
-        assertEq(token.balanceOf(address(567)), 20 ether);
-        assertEq(token.balanceOf(address(890)), 20 ether);
+        assertEq(token.balanceOf(address(123)), 20);
+        assertEq(token.balanceOf(address(234)), 20);
+        assertEq(token.balanceOf(address(567)), 20);
+        assertEq(token.balanceOf(address(890)), 20);
     }
 
     function testFail_gulp_multiple() public {

--- a/src/TokenFaucet.t.sol
+++ b/src/TokenFaucet.t.sol
@@ -26,7 +26,7 @@ contract TokenFaucetTest is DSTest {
         assertEq(token.balanceOf(address(234)), 0);
         assertEq(token.balanceOf(address(567)), 0);
         assertEq(token.balanceOf(address(890)), 0);
-        address payable[] memory addrs = new address payable[](4);
+        address[] memory addrs = new address[](4);
         addrs[0] = address(123);
         addrs[1] = address(234);
         addrs[2] = address(567);
@@ -40,7 +40,7 @@ contract TokenFaucetTest is DSTest {
 
     function testFail_gulp_multiple() public {
         faucet.gulp(address(token));
-        address payable[] memory addrs = new address payable[](4);
+        address[] memory addrs = new address[](4);
         addrs[0] = address(this);
         addrs[1] = address(234);
         addrs[2] = address(567);

--- a/src/TokenFaucet.t.sol
+++ b/src/TokenFaucet.t.sol
@@ -48,7 +48,7 @@ contract TokenFaucetTest is DSTest {
         faucet.gulp(address(token), addrs);
     }
 
-    function testFail_gulpTwice() public {
+    function testFail_gulp_twice() public {
         faucet.gulp(address(token));
         faucet.gulp(address(token));
     }

--- a/src/TokenFaucet.t.sol
+++ b/src/TokenFaucet.t.sol
@@ -52,6 +52,4 @@ contract TokenFaucetTest is DSTest {
         faucet.gulp(address(token));
         faucet.gulp(address(token));
     }
-
-    function() external payable {}
 }

--- a/src/TokenFaucet.t.sol
+++ b/src/TokenFaucet.t.sol
@@ -26,7 +26,7 @@ contract TokenFaucetTest is DSTest {
         assertEq(token.balanceOf(address(234)), 0);
         assertEq(token.balanceOf(address(567)), 0);
         assertEq(token.balanceOf(address(890)), 0);
-        address payable [] memory addrs = new address payable [](4);
+        address payable[] memory addrs = new address payable[](4);
         addrs[0] = address(123);
         addrs[1] = address(234);
         addrs[2] = address(567);
@@ -40,7 +40,7 @@ contract TokenFaucetTest is DSTest {
 
     function testFail_gulp_multiple() public {
         faucet.gulp(address(token));
-        address payable [] memory addrs = new address payable [](4);
+        address payable[] memory addrs = new address payable[](4);
         addrs[0] = address(this);
         addrs[1] = address(234);
         addrs[2] = address(567);


### PR DESCRIPTION
This adds one possible implementation of a whitelisted token faucet if we want to restrict who can receive tokens in one of our test environments. 

It adds an `owner` variable and turns the `wards` into the whitelist.  One downside of this is that it would add an additional `auth` scheme (owner + rely/deny), but as this is just for testing purposes, I felt that was better than introducing the complexity of DSAuth at this time.