### PR TITLE
Add note to faucets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/ds-token"]
 	path = lib/ds-token
 	url = https://github.com/dapphub/ds-token
+[submodule "lib/ds-note"]
+	path = lib/ds-note
+	url = https://github.com/dapphub/ds-note

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "lib/ds-token"]
 	path = lib/ds-token
 	url = https://github.com/dapphub/ds-token
-[submodule "lib/ds-note"]
-	path = lib/ds-note
-	url = https://github.com/dapphub/ds-note

--- a/src/RestrictedTokenFaucet.sol
+++ b/src/RestrictedTokenFaucet.sol
@@ -1,23 +1,25 @@
 pragma solidity >=0.5.0;
 
+import "./lib.sol";
+
 interface ERC20Like {
     function balanceOf(address) external view returns (uint256);
     function transfer(address,uint256) external; // return bool?
 }
 
-contract RestrictedTokenFaucet {
+contract RestrictedTokenFaucet is DSNote {
     // --- Auth ---
     mapping (address => uint) public wards;
-    function rely(address guy) public auth { wards[guy] = 1; }
-    function deny(address guy) public auth { wards[guy] = 0; }
+    function rely(address guy) public auth note { wards[guy] = 1; }
+    function deny(address guy) public auth note { wards[guy] = 0; }
     modifier auth {
         require(wards[msg.sender] == 1, "token-faucet/no-auth");
         _;
     }
     // --- Gulp Whitelist ---
     mapping (address => uint) public list;
-    function hope(address guy) public auth { list[guy] = 1; }
-    function nope(address guy) public auth { list[guy] = 0; }
+    function hope(address guy) public auth note { list[guy] = 1; }
+    function nope(address guy) public auth note { list[guy] = 0; }
 
     uint256 public amt;
     mapping (address => mapping (address => bool)) public done;

--- a/src/RestrictedTokenFaucet.sol
+++ b/src/RestrictedTokenFaucet.sol
@@ -57,11 +57,11 @@ contract RestrictedTokenFaucet is DSNote {
         gem.transfer(msg.sender, gem.balanceOf(address(this)));
     }
 
-    function undo(address usr, address gem) external auth {
+    function undo(address usr, address gem) external auth note {
         done[usr][gem] = false;
     }
 
-    function setamt(uint256 amt_) external auth {
+    function setamt(uint256 amt_) external auth note {
         amt = amt_;
     }
 }

--- a/src/TokenFaucet.sol
+++ b/src/TokenFaucet.sol
@@ -1,15 +1,17 @@
 pragma solidity >=0.5.0;
 
+import "./lib.sol";
+
 interface ERC20Like {
     function balanceOf(address) external view returns (uint256);
     function transfer(address,uint256) external; // return bool?
 }
 
-contract TokenFaucet {
+contract TokenFaucet is DSNote {
     // --- Auth ---
     mapping (address => uint) public wards;
-    function rely(address guy) public auth { wards[guy] = 1; }
-    function deny(address guy) public auth { wards[guy] = 0; }
+    function rely(address guy) public auth note { wards[guy] = 1; }
+    function deny(address guy) public auth note { wards[guy] = 0; }
     modifier auth { require(wards[msg.sender] == 1); _; }
 
     uint256 public amt;
@@ -45,7 +47,7 @@ contract TokenFaucet {
         gem.transfer(msg.sender, gem.balanceOf(address(this)));
     }
 
-    function setamt(uint256 amt_) external auth {
+    function setamt(uint256 amt_) external auth note {
         amt = amt_;
     }
 }

--- a/src/lib.sol
+++ b/src/lib.sol
@@ -1,0 +1,43 @@
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity >=0.4.23;
+
+contract DSNote {
+    event LogNote(
+        bytes4   indexed  sig,
+        address  indexed  usr,
+        bytes32  indexed  arg1,
+        bytes32  indexed  arg2,
+        bytes             data
+    ) anonymous;
+
+    modifier note {
+        _;
+        assembly {
+            // log an 'anonymous' event with a constant 6 words of calldata
+            // and four indexed topics: selector, caller, arg1 and arg2
+            let mark := msize                         // end of memory ensures zero
+            mstore(0x40, add(mark, 288))              // update free memory pointer
+            mstore(mark, 0x20)                        // bytes type data offset
+            mstore(add(mark, 0x20), 224)              // bytes size (padded)
+            calldatacopy(add(mark, 0x40), 0, 224)     // bytes payload
+            log4(mark, 288,                           // calldata
+                 shl(224, shr(224, calldataload(0))), // msg.sig
+                 caller,                              // msg.sender
+                 calldataload(4),                     // arg1
+                 calldataload(36)                     // arg2
+                )
+        }
+    }
+}


### PR DESCRIPTION
I noticed we aren't `note`ing anything on the Faucets. This adds it to the auth and other non-transfer functions.

Note: I copied the same DS-Note we use in `dss`. I did not want to import `dss` as a lib since it seemed like too much overhead for what we needed for this. 